### PR TITLE
add FileTypeDeserializer to handle unknown file types gracefully

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>cx.salted</groupId>
     <artifactId>whatsapp-business-java-api</artifactId>
-    <version>v0.6.2</version>
+    <version>v0.6.3</version>
     <licenses>
         <license>
             <name>The MIT License</name>

--- a/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
+++ b/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
@@ -2,9 +2,12 @@ package com.whatsapp.api;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.whatsapp.api.configuration.WhatsappApiConfig;
 import com.whatsapp.api.domain.errors.Error;
 import com.whatsapp.api.domain.errors.WhatsappApiError;
+import com.whatsapp.api.domain.media.FileType;
+import com.whatsapp.api.domain.media.FileTypeDeserializer;
 import com.whatsapp.api.domain.media.MediaFile;
 import com.whatsapp.api.exception.WhatsappApiException;
 import com.whatsapp.api.interceptor.AuthenticationInterceptor;
@@ -31,6 +34,7 @@ public class WhatsappApiServiceGenerator {
     static OkHttpClient sharedClient;
     private static final Converter.Factory converterFactory = JacksonConverterFactory.create(
         new ObjectMapper()
+          .registerModule(new SimpleModule().addDeserializer(FileType.class, new FileTypeDeserializer()))
           .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
           .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false)
           .configure(DeserializationFeature.FAIL_ON_UNRESOLVED_OBJECT_IDS, false)

--- a/src/main/java/com/whatsapp/api/domain/media/FileTypeDeserializer.java
+++ b/src/main/java/com/whatsapp/api/domain/media/FileTypeDeserializer.java
@@ -1,0 +1,21 @@
+package com.whatsapp.api.domain.media;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+
+public class FileTypeDeserializer extends JsonDeserializer<FileType> {
+
+    @Override
+    public FileType deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        String value = p.getText();
+        for (FileType fileType : FileType.values()) {
+            if (fileType.getType().equalsIgnoreCase(value)) {
+                return fileType;
+            }
+        }
+        return FileType.TEXT;
+    }
+}

--- a/src/test/java/com/whatsapp/api/impl/WhatsappBusinessCloudApiTest.java
+++ b/src/test/java/com/whatsapp/api/impl/WhatsappBusinessCloudApiTest.java
@@ -1007,6 +1007,24 @@ class WhatsappBusinessCloudApiTest extends MockServerUtilsTest {
     }
 
     @Test
+    void testRetrieveMediaUrlOfUnknownType() throws IOException, URISyntaxException, InterruptedException {
+        mockWebServer.enqueue(new MockResponse().newBuilder().code(200).body(fromResource("/mediaUnknownType.json")).build());
+
+        var response = whatsappBusinessCloudApi.retrieveMediaUrl("1227829768162607");
+
+        RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        Assertions.assertEquals("GET", recordedRequest.getMethod());
+        Assertions.assertEquals("/" + API_VERSION + "/" + "1227829768162607", recordedRequest.getPath());
+
+        Assertions.assertEquals("1227829768162607", response.id());
+        Assertions.assertEquals(103635L, response.fileSize());
+        Assertions.assertEquals(FileType.TEXT, response.mimeType());
+        Assertions.assertEquals("72fd8a734216768565faf2b59cec266eea00a78dd039ce84356319fc8c4ad22f", response.sha256());
+        Assertions.assertEquals("https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=1228169767822608&ext=16772107977&hash=ATs5BiSbLTZzCFh73M16stmnUK2UV6NBqChXB4WWC21ss", response.url());
+
+    }
+
+    @Test
     void testDownloadMediaFile() throws InterruptedException, IOException, URISyntaxException {
         mockWebServer.enqueue(new MockResponse().newBuilder().code(200).body(fromResource("/starwars.png")).addHeader("Content-Disposition", "inline;filename=starwars.png").build());
 

--- a/src/test/resources/mediaUnknownType.json
+++ b/src/test/resources/mediaUnknownType.json
@@ -1,0 +1,8 @@
+{
+  "url": "https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=1228169767822608&ext=16772107977&hash=ATs5BiSbLTZzCFh73M16stmnUK2UV6NBqChXB4WWC21ss",
+  "mime_type": "video/x-msvideo",
+  "sha256": "72fd8a734216768565faf2b59cec266eea00a78dd039ce84356319fc8c4ad22f",
+  "file_size": 103635,
+  "id": "1227829768162607",
+  "messaging_product": "whatsapp"
+}


### PR DESCRIPTION
- when deserializing Media, the mimeType field is only accepted if it matches the list of file types defined in the documentation. If a type like csv is provided even though it is listed, it fails with the error