### PR TITLE
Text parameter is missing default constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>cx.salted</groupId>
     <artifactId>whatsapp-business-java-api</artifactId>
-    <version>v0.6.7</version>
+    <version>v0.6.8</version>
     <licenses>
         <license>
             <name>The MIT License</name>

--- a/src/main/java/com/whatsapp/api/domain/messages/TextParameter.java
+++ b/src/main/java/com/whatsapp/api/domain/messages/TextParameter.java
@@ -12,7 +12,11 @@ import com.whatsapp.api.domain.messages.type.ParameterType;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TextParameter extends Parameter {
     @JsonProperty("text")
-    private final String text;
+    private String text;
+
+    public TextParameter() {
+        super(ParameterType.TEXT);
+    }
 
 
     /**


### PR DESCRIPTION
Jackson is not happy about this:
```
Cannot construct instance of `com.whatsapp.api.domain.messages.TextParameter` (although at least one Creator exists): cannot deserialize from Object value (no delegate- or property-based Creator)```