### PR TITLE
allow streaming media to Whatsapp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>cx.salted</groupId>
     <artifactId>whatsapp-business-java-api</artifactId>
-    <version>v0.6.14</version>
+    <version>v0.6.15</version>
     <licenses>
         <license>
             <name>The MIT License</name>

--- a/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
+++ b/src/main/java/com/whatsapp/api/WhatsappApiServiceGenerator.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class WhatsappApiServiceGenerator {
 
-    static OkHttpClient sharedClient;
+    public static OkHttpClient sharedClient;
     private static final Converter.Factory converterFactory = JacksonConverterFactory.create(
         new ObjectMapper()
           .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)

--- a/src/test/java/com/whatsapp/api/TestUtils.java
+++ b/src/test/java/com/whatsapp/api/TestUtils.java
@@ -1,5 +1,6 @@
 package com.whatsapp.api;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -20,6 +21,10 @@ public class TestUtils {
         return new String(encoded, StandardCharsets.UTF_8);
 
 
+    }
+
+    public File fileFromResource(String fileName) throws URISyntaxException {
+        return Paths.get(Objects.requireNonNull(this.getClass().getResource(fileName)).toURI()).toFile();
     }
 
     /**

--- a/src/test/java/com/whatsapp/api/impl/WhatsappBusinessCloudApiTest.java
+++ b/src/test/java/com/whatsapp/api/impl/WhatsappBusinessCloudApiTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
@@ -987,6 +988,23 @@ class WhatsappBusinessCloudApiTest extends MockServerUtilsTest {
         Assertions.assertEquals(103923, recordedRequest.getBodySize());
         Assertions.assertEquals("985569392615996", response.id());
     }
+
+    @Test
+    void testUploadMedia2() throws IOException, URISyntaxException, InterruptedException {
+        mockWebServer.enqueue(new MockResponse().newBuilder().code(200).body(fromResource("/uploadResponse.json")).build());
+
+        var file = fileFromResource("/starwars.png");
+
+
+        var response = whatsappBusinessCloudApi.uploadMedia(PHONE_NUMBER_ID, "starwars.png", "image/png", new FileInputStream(file));
+
+        RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        Assertions.assertEquals("POST", recordedRequest.getMethod());
+        Assertions.assertEquals("/" + API_VERSION + "/" + PHONE_NUMBER_ID + "/media", recordedRequest.getPath());
+        Assertions.assertEquals(103923, recordedRequest.getBodySize());
+        Assertions.assertEquals("985569392615996", response.id());
+    }
+
 
     @Test
     void testRetrieveMediaUrl() throws IOException, URISyntaxException, InterruptedException {


### PR DESCRIPTION
we want to avoid reading the whole (possibly large) content of the media into memory.
let's allow alternative way that streams the media using `OkHttpClient`. Caller will simply pass an input stream.